### PR TITLE
Fix bug parsing URL

### DIFF
--- a/packages/laminar/src/http/request.ts
+++ b/packages/laminar/src/http/request.ts
@@ -20,7 +20,7 @@ export function toHttpRequest(incommingMessage: IncomingMessage): HttpContext {
   const host = (headers['x-forwarded-host'] as string)?.split(',')[0] ?? headers['host'];
   let url = ''
     try {
-      url = new URL(incommingMessage.url !== null && incommingMessage.url !== undefined ? incommingMessage.url : '', `${protocol}://${host}`);
+      url = new URL(incommingMessage.url ?? '', `${protocol}://${host}`);
     } catch(err) {
       url = new URL('/', `${protocol}://${host}`);
     }

--- a/packages/laminar/src/http/request.ts
+++ b/packages/laminar/src/http/request.ts
@@ -20,7 +20,7 @@ export function toHttpRequest(incommingMessage: IncomingMessage): HttpContext {
   const host = (headers['x-forwarded-host'] as string)?.split(',')[0] ?? headers['host'];
   let url = ''
     try {
-      url = new URL(incommingMessage.url !== null && incommingMessage.url !== void 0 ? incommingMessage.url : '', `${protocol}://${host}`);
+      url = new URL(incommingMessage.url !== null && incommingMessage.url !== undefined ? incommingMessage.url : '', `${protocol}://${host}`);
     } catch(err) {
       url = new URL('/', `${protocol}://${host}`);
     }

--- a/packages/laminar/src/http/request.ts
+++ b/packages/laminar/src/http/request.ts
@@ -20,7 +20,7 @@ export function toHttpRequest(incommingMessage: IncomingMessage): HttpContext {
   const host = (headers['x-forwarded-host'] as string)?.split(',')[0] ?? headers['host'];
   let url = ''
     try {
-      url = new URL((incommingMessage.url) !== null && incommingMessage.url !== void 0 ? incommingMessage.url : '', `${protocol}://${host}`);
+      url = new URL(incommingMessage.url !== null && incommingMessage.url !== void 0 ? incommingMessage.url : '', `${protocol}://${host}`);
     } catch(err) {
       url = new URL('/', `${protocol}://${host}`);
     }

--- a/packages/laminar/src/http/request.ts
+++ b/packages/laminar/src/http/request.ts
@@ -18,7 +18,12 @@ export function toHttpRequest(incommingMessage: IncomingMessage): HttpContext {
   const headers = incommingMessage.headers;
   const method = incommingMessage.method ?? '';
   const host = (headers['x-forwarded-host'] as string)?.split(',')[0] ?? headers['host'];
-  const url = new URL(incommingMessage.url ?? '', `${protocol}://${host}`);
+  let url = ''
+    try {
+      url = new url_1.URL((_d = incommingMessage.url) !== null && _d !== void 0 ? _d : '', `${protocol}://${host}`);
+    } catch(err) {
+      url = new url_1.URL('/', `${protocol}://${host}`);
+    }
   const query = parseQueryObjects(new URLSearchParams(incommingMessage.url?.split('?')?.[1] ?? ''));
   const cookies = headers.cookie ? parseCookie(headers.cookie) : undefined;
 

--- a/packages/laminar/src/http/request.ts
+++ b/packages/laminar/src/http/request.ts
@@ -20,9 +20,9 @@ export function toHttpRequest(incommingMessage: IncomingMessage): HttpContext {
   const host = (headers['x-forwarded-host'] as string)?.split(',')[0] ?? headers['host'];
   let url = ''
     try {
-      url = new url_1.URL((_d = incommingMessage.url) !== null && _d !== void 0 ? _d : '', `${protocol}://${host}`);
+      url = new URL((incommingMessage.url) !== null && incommingMessage.url !== void 0 ? incommingMessage.url : '', `${protocol}://${host}`);
     } catch(err) {
-      url = new url_1.URL('/', `${protocol}://${host}`);
+      url = new URL('/', `${protocol}://${host}`);
     }
   const query = parseQueryObjects(new URLSearchParams(incommingMessage.url?.split('?')?.[1] ?? ''));
   const cookies = headers.cookie ? parseCookie(headers.cookie) : undefined;


### PR DESCRIPTION
- Don't create an URL if it's invalid This will prevent the following unhandled error: 
```
TypeError [ERR_INVALID_URL]: Invalid URL
    ...
    at new URL (node:internal/url:628:5)
    at toHttpRequest 
    ... 
 (node:_http_common:128:17) {
  input: '///%3C%3E//example.com',
  code: 'ERR_INVALID_URL'
}
```